### PR TITLE
Trivial fix for TAB completion on Arch Linux

### DIFF
--- a/fizsh-1.0.2/scripts/fizshrc.zsh
+++ b/fizsh-1.0.2/scripts/fizshrc.zsh
@@ -104,7 +104,8 @@ title
 
 # Initiate completion system
 #
-autoload -U compinit compinit
+autoload -U compinit 
+compinit
 zmodload zsh/complist
 
 # Enable color support of ls


### PR DESCRIPTION
On my system (Arch Linux), TAB completion fails to load properly with autoload -U compinit compinit.  Putting
the second compinit on the next line fixed the issue.

Note:  I have zsh 4.3.12 on x86_64 from the official Arch repositories.
