### PR TITLE
fix using wrong path when installed in /sbin

### DIFF
--- a/scripts/fizsh
+++ b/scripts/fizsh
@@ -63,7 +63,7 @@ fi
 
 export _fizsh_F_FIZSH_FULL_PATH=$(which $_fizsh_F_FIZSH)
 export _fizsh_F_BIN_DIR=$(echo $_fizsh_F_FIZSH_FULL_PATH | sed -e "s/\/$_fizsh_F_FIZSH//")
-export _fizsh_F_ETC_DIR=$(echo $_fizsh_F_BIN_DIR | sed -e "s/bin/etc/")/$_fizsh_F_FIZSH
+export _fizsh_F_ETC_DIR=$(echo $_fizsh_F_BIN_DIR | sed -r "s/s?bin/etc/")/$_fizsh_F_FIZSH
 [[ $_fizsh_F_ETC_DIR == "/usr/etc/$_fizsh_F_FIZSH" ]] && export _fizsh_F_ETC_DIR="/etc/$_fizsh_F_FIZSH" # needed on systems like Debian
 _fizsh_F_PS=1; which ps > /dev/null || _fizsh_F_PS=0; export _fizsh_F_PS
 


### PR DESCRIPTION
In #20, I had an issue where fizsh would try to copy scripts from `/setc`, a nonexistent directory, instead of `/etc`. After some quick investigation, it turns out that a `sed` command that converted fizsh's location in `/bin` to the scripts' location in `/etc` was to blame.

On my system, fizsh was installed to `/sbin`, which would get turned into `/setc`. This pull request fixes the `sed` command responsible for this bug so that fizsh now works properly even if it is installed in `/sbin`.